### PR TITLE
Fix error with parsing .json files in afterLaunch function

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,11 @@ function HierarchicalHTMLReporter(options) {
         var failures = 0;
         var skipped = 0;
         var allStats = 0;
-        var list = fs.readdirSync(self.savePath);
+        var list = fs.readdirSync(self.savePath)
+                     .filter(function(fileName) {
+                        return path.extname(fileName) === '.json';
+                     });
+
         for (var i = 0; i < list.length; i++) {
             var filename = path.join(self.savePath, list[i]);
             if (fs.statSync(filename).isDirectory()) {


### PR DESCRIPTION
In afterLaunch function all json files from savePath are parsed. But among them there is .html file which breaks this functionality. To fix it we get just .json files from savePath folder.